### PR TITLE
object is now a PHP reserved word (PHP >7.2)

### DIFF
--- a/desktop/php/jeelog.php
+++ b/desktop/php/jeelog.php
@@ -82,7 +82,7 @@ foreach ($eqLogics as $eqLogic) {
                   <select id="sel_object" class="eqLogicAttr form-control" data-l1key="object_id">
                       <option value="">{{Aucun}}</option>
                       <?php
-                        foreach (object::all() as $object) {
+                        foreach (jeeObject::all() as $object) {
                          echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
                         }
                       ?>


### PR DESCRIPTION
Permet au plugin de fonctionner avec PHP >7.2

Sans la modif, lorsqu'on affiche la page de configuration du plugin on obtient une page blanche.
Si l'on rafraîchit, les menus jeedom sont affichés avec des doubles accolades (ex : `{{ Plugins }}` ) et les boutons `Ajouter` et `Configuration` ne produisent aucun effet.

NB : cette modif a déjà été appliquée sur la branche v4 mais pas sur la version stable pour Jeedom v3